### PR TITLE
docs: support MANY_INTERNAL conversations in OpenAPI spec

### DIFF
--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -502,11 +502,11 @@ paths:
           content:
             application/json:
               examples:
-                INTERNAL_PARTICIPANTS_REQUIRED:
+                MIN_PARTICIPANTS_REQUIRED:
                   value:
-                    title: Internal Participants Required
+                    title: Min Participants Required
                     status: 400
-                    code: BRIDGE_CONVERSATION_0202
+                    code: BRIDGE_CONVERSATION_0210
               schema:
                 $ref: '#/components/schemas/Problem'
         '403':

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -462,12 +462,12 @@ paths:
       - Conversations API
       summary: Creates a new conversation with flexible user identification.
       description: |
-        Create a new conversation with flexible user identification.
+        Create a new conversation with flexible participant identification.
 
-        External users (contacts) can be identified by ID, email, or phone.
-        Internal users are only assigned when explicitly specified; otherwise, conversations are auto-assigned by round-robin through a team or left open for any available internal user.
+        Contacts can be identified by ID, email, or phone.
+        Bridge users (your internal team members) are only assigned when explicitly specified; otherwise, conversations are auto-assigned by round-robin through a team or left open for any available Bridge user.
 
-        To create an internal-only conversation (with no external contacts), omit `participants.externals` or pass an empty array, and provide at least 2 entries in `participants.internals`.
+        To create an internal-only conversation (with no contacts), omit `participants.externals` or pass an empty array, and provide at least 2 entries in `participants.internals` (the Bridge users participating in the thread).
       operationId: create_conversation_bridge_api_v1_workspaces__workspaceId__conversations_post
       security:
       - x-api-key: []

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -467,7 +467,7 @@ paths:
         External users (contacts) can be identified by ID, email, or phone.
         Internal users are only assigned when explicitly specified; otherwise, conversations are auto-assigned by round-robin through a team or left open for any available internal user.
 
-        To create an internal-only conversation (type MANY_INTERNAL, no external contacts), omit `participants.externals` or pass an empty array, and provide at least 2 entries in `participants.internals`.
+        To create an internal-only conversation (with no external contacts), omit `participants.externals` or pass an empty array, and provide at least 2 entries in `participants.internals`.
       operationId: create_conversation_bridge_api_v1_workspaces__workspaceId__conversations_post
       security:
       - x-api-key: []

--- a/api-reference/openapi.yaml
+++ b/api-reference/openapi.yaml
@@ -461,16 +461,13 @@ paths:
       tags:
       - Conversations API
       summary: Creates a new conversation with flexible user identification.
-      description: 'Create a new conversation with flexible user identification.
+      description: |
+        Create a new conversation with flexible user identification.
 
+        External users (contacts) can be identified by ID, email, or phone.
+        Internal users are only assigned when explicitly specified; otherwise, conversations are auto-assigned by round-robin through a team or left open for any available internal user.
 
-        External users can be identified by ID, email, or phone.
-
-        Internal users are only assigned when explicitly specified; otherwise, conversations
-        are
-
-        auto-assigned by round-robin through a team or left open for any available
-        internal user.'
+        To create an internal-only conversation (type MANY_INTERNAL, no external contacts), omit `participants.externals` or pass an empty array, and provide at least 2 entries in `participants.internals`.
       operationId: create_conversation_bridge_api_v1_workspaces__workspaceId__conversations_post
       security:
       - x-api-key: []
@@ -505,11 +502,11 @@ paths:
           content:
             application/json:
               examples:
-                EXTERNAL_PARTICIPANTS_REQUIRED:
+                INTERNAL_PARTICIPANTS_REQUIRED:
                   value:
-                    title: External Participants Required
+                    title: Internal Participants Required
                     status: 400
-                    code: BRIDGE_CONVERSATION_0201
+                    code: BRIDGE_CONVERSATION_0202
               schema:
                 $ref: '#/components/schemas/Problem'
         '403':


### PR DESCRIPTION
## Summary

- **Updated endpoint description** for `POST /bridge/api/v1/workspaces/{workspaceId}/conversations` to document the internal-only conversation flow: omit `participants.externals` (or pass an empty array) and provide ≥ 2 entries in `participants.internals` to create a `MANY_INTERNAL` conversation.
- **Removed** the `EXTERNAL_PARTICIPANTS_REQUIRED` (400) error example — this error code (`BRIDGE_CONVERSATION_0201`) no longer applies; passing `externals=[]` is now valid when at least 2 internal participants are provided.
- **Added** the new `INTERNAL_PARTICIPANTS_REQUIRED` (400) error example (`BRIDGE_CONVERSATION_0202`) — returned when `externals` is empty/omitted **and** fewer than 2 internal participants are provided.

## Motivation

The Integrations API now supports creating `MANY_INTERNAL` conversations (internal users only, no external contacts). Previously, `externals=[]` always returned `400 EXTERNAL_PARTICIPANTS_REQUIRED`. This spec update reflects the new behaviour.

Related: Sainapsis/sainapsis-documentation-generic-repo#772

## Test plan

- [ ] Verify the updated OpenAPI spec renders correctly in Mintlify (description block, error example key/title/code).
- [ ] Confirm no other endpoint in the spec references `BRIDGE_CONVERSATION_0201` or `EXTERNAL_PARTICIPANTS_REQUIRED` that would now be stale.
- [ ] YAML syntax validated locally with `python -c "import yaml; yaml.safe_load(open('api-reference/openapi.yaml'))"` — passes.