### PR TITLE
feat(lead-capture): publish the campaign-leads integration documentation

### DIFF
--- a/api-reference/campaign-leads.openapi.yaml
+++ b/api-reference/campaign-leads.openapi.yaml
@@ -1,0 +1,244 @@
+openapi: 3.1.0
+info:
+  title: Bridge Campaign Leads API
+  description: 'Public endpoint for registering leads captured by a tenant''s landing
+    page. No API key is required: the caller is identified by its workspace and capture
+    key together with a reCAPTCHA v3 token.'
+  version: 1.0.0
+servers:
+- url: https://integrations-us.app.bridge.new/api/v1
+paths:
+  /leadscout/campaign-leads:
+    post:
+      tags:
+      - Campaign leads
+      summary: Register a campaign lead
+      description: Registers a lead captured by a tenant's landing page and queues
+        the first outbound WhatsApp message. A 202 means the lead was accepted, not
+        that a message was sent.
+      operationId: create_campaign_lead_leadscout_campaign_leads_post
+      parameters:
+      - description: Required when calling from a browser. A CORS preflight carries
+          no body, so the tenant cannot be resolved — and Access-Control-Allow-Origin
+          cannot be echoed — unless the workspace is on the URL. Server-to-server
+          callers do not preflight and may omit it.
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Workspaceid
+          description: Required when calling from a browser. A CORS preflight carries
+            no body, so the tenant cannot be resolved — and Access-Control-Allow-Origin
+            cannot be echoed — unless the workspace is on the URL. Server-to-server
+            callers do not preflight and may omit it.
+        name: workspaceId
+        in: query
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CampaignLeadRequestDto'
+        required: true
+      responses:
+        '422':
+          description: The captcha provider could not be reached. Transient; retrying
+            is safe.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsDto'
+        '202':
+          description: Accepted and queued. NOT sent — a separate service transmits
+            the first message later.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CampaignLeadAcceptedDto'
+        '400':
+          description: Malformed payload, unusable phone, consent not granted, or
+            a missing brand.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsDto'
+        '403':
+          description: Capture disabled, capture key mismatch, captcha rejected, or
+            origin not allowed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsDto'
+        '500':
+          description: Unexpected failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetailsDto'
+components:
+  schemas:
+    CampaignLeadAcceptedDto:
+      properties:
+        requestId:
+          type: string
+          title: Requestid
+          description: Correlation id for this submission. Present on acceptance only;
+            error responses do not carry one.
+      type: object
+      required:
+      - requestId
+      title: CampaignLeadAcceptedDto
+      description: 'Body of the `202 Accepted` response.
+
+
+        Named rather than a bare `dict[str, str]` so the published schema states what
+        the
+
+        single field is and what it is for, instead of "an object with string properties".'
+    CampaignLeadRequestDto:
+      properties:
+        workspaceId:
+          type: string
+          title: Workspaceid
+        captureKey:
+          type: string
+          title: Capturekey
+        cellphone:
+          type: string
+          title: Cellphone
+        name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Name
+        brandId:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Brandid
+        landingUri:
+          type: string
+          title: Landinguri
+        utm:
+          additionalProperties:
+            type: string
+          type: object
+          title: Utm
+        consent:
+          $ref: '#/components/schemas/ConsentDto'
+        recaptchaToken:
+          type: string
+          title: Recaptchatoken
+      type: object
+      required:
+      - workspaceId
+      - captureKey
+      - cellphone
+      - landingUri
+      - consent
+      - recaptchaToken
+      title: CampaignLeadRequestDto
+      description: Wire contract for `POST api/v1/leadscout/campaign-leads`.
+    ConsentDto:
+      properties:
+        status:
+          $ref: '#/components/schemas/ConsentStatus'
+        capturedAt:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Capturedat
+      type: object
+      required:
+      - status
+      title: ConsentDto
+      description: 'The tenant''s attestation that the visitor gave permission to
+        be messaged.
+
+
+        This is NOT `CommercialConsentState`, which is our own record of a contact''s
+        opt-in
+
+        lifecycle. This is a claim arriving from outside, and it is not verifiable
+        by us: it
+
+        proves what we were told and when, which is what we would present if a tenant''s
+
+        portfolio were ever restricted.'
+    ConsentStatus:
+      type: string
+      enum:
+      - GRANTED
+      - NOT_PROVIDED
+      title: ConsentStatus
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          type: array
+          title: Detail
+      type: object
+      title: HTTPValidationError
+    ProblemDetailsDto:
+      properties:
+        type:
+          type: string
+          title: Type
+          description: Stable machine-readable error code.
+        title:
+          type: string
+          title: Title
+          description: Short human-readable summary.
+        status:
+          type: integer
+          title: Status
+          description: HTTP status code, repeated in the body.
+        detail:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Detail
+          description: Optional elaboration. Absent on most rejections.
+      type: object
+      required:
+      - type
+      - title
+      - status
+      title: ProblemDetailsDto
+      description: 'RFC 9457 problem details, as the global exception handler emits
+        them.
+
+
+        Context is deliberately stripped before this reaches a caller: on a public
+        endpoint,
+
+        a detailed rejection tells an attacker which check they failed.'
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          type: array
+          title: Location
+        type:
+          type: string
+          title: Error Type
+      type: object
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError
+    ResponseValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          type: array
+          title: Detail
+      type: object
+      title: ResponseValidationError

--- a/docs.json
+++ b/docs.json
@@ -11,11 +11,11 @@
   "favicon": "/favicon.png",
   "markdown": {
     "instructions": [
-      "Bridge exposes two integration surfaces: the REST Integrations API for pushing data into Bridge, and webhooks for receiving events from Bridge.",
-      "The API host is https://api-connect-us.bridge.new. Do not use any other host.",
-      "Authenticate every API request with the x-api-key header. Bridge does not use bearer tokens or OAuth.",
-      "Error codes follow the BRIDGE_<DOMAIN>_<NNNN> format, for example BRIDGE_CONVERSATION_0001. Never invent a code that is not listed on the error codes page.",
-      "This documentation covers the Integrations API only. It does not describe the Bridge web application or its internal APIs."
+      "Bridge exposes three integration surfaces: the REST Integrations API for pushing data into Bridge, webhooks for receiving events from Bridge, and the public Lead Capture endpoint that a tenant's landing page posts to.",
+      "The Integrations API host is https://api-connect-us.bridge.new and every request to it must be authenticated with the x-api-key header. Bridge does not use bearer tokens or OAuth.",
+      "The Lead Capture endpoint is different and the Integrations API rules do not apply to it: it has its own host, it takes no x-api-key and no authentication header of any kind, and it is called from a visitor's browser. It is identified by a workspace id and a capture key together with a reCAPTCHA token. Never tell a reader to authenticate it with an API key, and never tell them to keep its capture key out of frontend code - it is designed to live in the page.",
+      "Integrations API error codes follow the BRIDGE_<DOMAIN>_<NNNN> format, for example BRIDGE_CONVERSATION_0001, and are listed on the error codes page. Lead Capture error codes follow a different format, BRIDGE.CAMPAIGN_LEADS.<NAME>, and are listed on the Lead Capture error reference. Never invent a code that is not listed on the page for its own surface.",
+      "This documentation covers the Integrations API, webhooks and Lead Capture only. It does not describe the Bridge web application or its internal APIs."
     ]
   },
   "navigation": {

--- a/docs.json
+++ b/docs.json
@@ -34,6 +34,33 @@
         "openapi": "api-reference/openapi.yaml"
       },
       {
+        "tab": "Lead Capture",
+        "groups": [
+          {
+            "group": "Integration",
+            "pages": [
+              "lead-capture/index",
+              "lead-capture/integration",
+              "lead-capture/errors"
+            ]
+          },
+          {
+            "group": "Endpoint",
+            "openapi": "api-reference/campaign-leads.openapi.yaml",
+            "pages": [
+              "POST /leadscout/campaign-leads"
+            ]
+          },
+          {
+            "group": "Before you launch",
+            "pages": [
+              "lead-capture/consent",
+              "lead-capture/templates"
+            ]
+          }
+        ]
+      },
+      {
         "tab": "Webhooks",
         "pages": [
           "webhooks",

--- a/lead-capture/consent.mdx
+++ b/lead-capture/consent.mdx
@@ -1,0 +1,65 @@
+---
+title: "Consent requirements"
+sidebarTitle: "Consent"
+description: "What your opt-in must say, and what you are attesting to when you send consent.status GRANTED."
+keywords: ["consent", "opt-in", "WhatsApp", "compliance", "Meta"]
+---
+
+## What your form must carry
+
+Your landing page must ask for an explicit opt-in before you submit a lead. The wording is
+yours to write, but it has to do two things Meta requires:
+
+- **Name your business.** Not "us", not "our partners" — the business the person will hear
+  from.
+- **Say the person will receive WhatsApp communication from it.** Not "we may contact you";
+  name the channel.
+
+Meta lists a website form as a compliant way to collect this, so a checkbox on your landing
+page is enough — provided it says both of those things.
+
+<Warning>
+  A pre-ticked box is not an opt-in. Neither is a line of small print under a submit button
+  that the visitor never interacts with. The visitor has to take the action.
+</Warning>
+
+## What you are attesting to
+
+<Note>
+  Sending `consent.status: "GRANTED"` is an attestation **you** are making. We do not and
+  cannot verify that the visitor ticked a box — we record that you told us they did, and
+  when. If your WhatsApp sending is ever restricted, that record is what is presented on
+  your behalf.
+</Note>
+
+This is why `capturedAt` matters more than it looks. It must be the moment the visitor
+actually consented — not the moment your server got around to sending the request, and not a
+timestamp generated during a nightly batch. If the two ever have to be defended, the gap
+between them is the first thing anyone will look at.
+
+Send it as an ISO 8601 timestamp:
+
+```json
+{
+  "consent": {
+    "status": "GRANTED",
+    "capturedAt": "2026-08-26T14:32:07.184Z"
+  }
+}
+```
+
+If consent was not given, do not submit the lead. A submission with any status other than
+`GRANTED` is rejected with `BRIDGE.CAMPAIGN_LEADS.CONSENT_NOT_GRANTED`.
+
+## An example to adapt
+
+This is illustrative, not boilerplate to paste. Only you know what you will send and why,
+and the wording has to match that.
+
+> ☐ I agree to receive WhatsApp messages from **Acme Motors** about the quote I just
+> requested.
+
+What makes it work: it names the business, it names the channel, and it says what the
+messages will be about. What would break it: dropping the business name, saying "messages"
+without saying WhatsApp, or bundling the consent into a general terms-and-conditions
+checkbox that also covers unrelated things.

--- a/lead-capture/errors.mdx
+++ b/lead-capture/errors.mdx
@@ -1,0 +1,68 @@
+---
+title: "Error reference"
+sidebarTitle: "Errors"
+description: "Every response the campaign-leads endpoint can return, and whether you can fix it."
+keywords: ["errors", "422", "403", "captcha", "troubleshooting"]
+---
+
+Error responses are [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) problem details: a
+`type`, a `title`, a `status`, and sometimes a `detail`.
+
+<Note>
+  **Error responses do not carry a request id.** Only a successful `202` does. If you need
+  to raise something with support, report the page URL and the approximate time instead.
+</Note>
+
+## Every response
+
+| Status | `type` | What happened | Can you fix it? |
+| --- | --- | --- | --- |
+| `400` | `invalid_payload` | A field is missing or malformed. | Yes |
+| `400` | `BRIDGE.CAMPAIGN_LEADS.INVALID_PHONE` | The phone number could not be read as a real number. | Yes — validate before submitting |
+| `400` | `BRIDGE.CAMPAIGN_LEADS.CONSENT_NOT_GRANTED` | `consent.status` was not `GRANTED`. | Yes |
+| `400` | `BRIDGE.CAMPAIGN_LEADS.BRAND_OR_LINE_REQUIRED` | Your workspace has brands enabled and no `brandId` was sent. | Yes |
+| `403` | `BRIDGE.CAMPAIGN_LEADS.CAPTURE_DISABLED` | Lead capture is not enabled for this workspace. | No — contact Bridge |
+| `403` | `BRIDGE.CAMPAIGN_LEADS.CAPTURE_KEY_MISMATCH` | The capture key is missing or wrong. | Yes |
+| `403` | `BRIDGE.CAMPAIGN_LEADS.CAPTCHA_REJECTED` | The captcha token was missing, expired, already used, or scored too low. | Sometimes — see below |
+| `403` | `BRIDGE.CAMPAIGN_LEADS.ORIGIN_NOT_ALLOWED` | The page's domain is not registered for this workspace. | No — contact Bridge |
+| `422` | `BRIDGE.CAMPAIGN_LEADS.CAPTCHA_PROVIDER_UNAVAILABLE` | We could not reach the captcha provider. | Retrying is safe |
+| `500` | `unexpected_error` | Something failed on our side. | No |
+
+Only the first failure is reported. Checks run in this order: workspace and capture key,
+then the phone number, then consent, then the brand, then the captcha and finally the
+domain. Fixing one error can reveal the next.
+
+## About the captcha rejection
+
+`CAPTCHA_REJECTED` covers four different situations, and two of them are yours to fix:
+
+- **The token expired.** It was minted too early. A reCAPTCHA v3 token lasts about two
+  minutes; mint it when the form is submitted, not when the page loads.
+- **The token was already used.** A token verifies once. If you retried a failed submission
+  without minting a new token, the replay is rejected.
+- **The score was too low**, or **no token was sent at all.** These two are the anti-bot
+  check doing its job. There is nothing to fix in your integration.
+
+Because all four return the same code, the useful diagnostic is whether the same visitor
+succeeds on a second attempt with a fresh token. If they do, it was timing, not a bot.
+
+## About the 422
+
+This is a transient failure on our side: we could not reach the captcha provider, so we
+could not decide whether the submission was genuine.
+
+**Retrying is safe.** The lead is preserved when this happens, and a retry cannot produce a
+duplicate message. Mint a fresh captcha token for the retry, as you would for any other one.
+
+## About the domain error
+
+The ordering here is genuinely surprising, so it is worth stating plainly.
+
+Your page's domain is checked against the domains registered for your workspace — but the
+domain we check is the one the **captcha provider reports**, not the one in the request's
+own headers. That check happens *after* the token verifies.
+
+The practical consequence: a page served from an unregistered domain fails at the captcha
+stage with `ORIGIN_NOT_ALLOWED`, not with a CORS error. If you are seeing this while your
+integration otherwise works, the domain is missing from your workspace configuration —
+contact Bridge to have it added.

--- a/lead-capture/index.mdx
+++ b/lead-capture/index.mdx
@@ -1,0 +1,49 @@
+---
+title: "Lead Capture"
+sidebarTitle: "Overview"
+description: "Register leads from your landing page and open a WhatsApp conversation with them automatically."
+keywords: ["lead capture", "landing page", "campaign leads", "WhatsApp", "reCAPTCHA"]
+---
+
+## What this does
+
+Your landing page posts a lead to Bridge. Bridge then opens the WhatsApp conversation for
+you, using an approved template. You do not send the message; we do.
+
+<Warning>
+  **A `202` response means the lead was accepted, not that a message was sent.** The first
+  WhatsApp message is transmitted later by a separate service. Your thank-you copy must say
+  something like "we'll message you shortly" — never "we've messaged you".
+</Warning>
+
+## What you need, and where it comes from
+
+Four values: the endpoint URL, your `captureKey`, the reCAPTCHA site key, and the reCAPTCHA
+action name.
+
+You do not assemble them by hand. In the Bridge admin console, under **LeadScout → Capture
+snippet**, an administrator of your workspace generates an integration example that already
+contains all four. They hand that block to whoever builds the page — that person never needs
+console access.
+
+<Note>
+  The example is a starting point, not a drop-in script. You own your form markup and your
+  consent wording; see [Consent requirements](/lead-capture/consent).
+</Note>
+
+## Where to go next
+
+<CardGroup cols={2}>
+  <Card title="Integration guide" icon="code" href="/lead-capture/integration">
+    The example, and the three rules that are not guessable from the contract.
+  </Card>
+  <Card title="Error reference" icon="triangle-exclamation" href="/lead-capture/errors">
+    Every response the endpoint can return, and which ones you can fix.
+  </Card>
+  <Card title="Consent requirements" icon="clipboard-check" href="/lead-capture/consent">
+    What your opt-in must say, and what you are attesting to.
+  </Card>
+  <Card title="Template requirements" icon="message" href="/lead-capture/templates">
+    Why your template must stay transactional.
+  </Card>
+</CardGroup>

--- a/lead-capture/integration.mdx
+++ b/lead-capture/integration.mdx
@@ -1,0 +1,235 @@
+---
+title: "Integration guide"
+sidebarTitle: "Integration"
+description: "Post a lead from your landing page: the example, and the three rules that are not obvious from the contract."
+keywords: ["integration", "reCAPTCHA", "CORS", "campaign leads", "example"]
+---
+
+## The example
+
+The Bridge admin console generates this block already filled in with your workspace's
+values. The version below uses placeholders so you can read it before you have them.
+
+Replace the form markup and the consent wording with your own. The script underneath only
+needs to change if your field ids differ from the ones used here.
+
+```html
+<!--
+  Campaign leads integration example.
+  This is a starting point, not a drop-in script: replace the form fields, labels and
+  consent copy below with your own. The integration script does not need to change unless
+  your form's field ids differ from the ones used here.
+  What this does: collects a phone number (and optionally a name), mints a reCAPTCHA v3
+  token, and POSTs the lead to the campaign-leads endpoint. A 202 response means the lead
+  was accepted and queued -- a separate service sends the first WhatsApp message later, so
+  do not tell the visitor "message sent"; something like "we'll message you shortly" is
+  accurate.
+-->
+<script>
+  window.__CAMPAIGN_LEADS__ = {"workspaceId":"YOUR_WORKSPACE_ID","captureKey":"YOUR_CAPTURE_KEY","endpoint":"https://integrations-us.app.bridge.new/api/v1/leadscout/campaign-leads","brandId":null,"recaptchaSiteKey":"YOUR_RECAPTCHA_SITE_KEY","recaptchaAction":"submit_campaign_lead","trackedParams":[]};
+</script>
+<!-- ============================================================
+     EXAMPLE FORM -- replace with your own markup and consent copy.
+     Keep the element ids (or update the selectors in the script below to match yours).
+     ============================================================ -->
+<form id="lead-form" novalidate>
+  <label>
+    <span>Name (optional)</span>
+    <input id="lead-name" type="text" autocomplete="name" />
+  </label>
+  <label>
+    <span>WhatsApp number</span>
+    <input id="lead-phone" type="tel" autocomplete="tel" required />
+  </label>
+  <!-- The wording of this consent statement is yours to write: it is what the visitor is
+       agreeing to, and only you know what you will message them and why. -->
+  <label>
+    <input id="lead-consent" type="checkbox" required />
+    <span>I agree to be contacted by WhatsApp.</span>
+  </label>
+  <button type="submit">Submit</button>
+</form>
+<script>
+  (function (config) {
+    "use strict";
+    var form = document.getElementById("lead-form");
+    function loadRecaptcha() {
+      return new Promise(function (resolve, reject) {
+        if (window.grecaptcha) {
+          resolve();
+          return;
+        }
+        var tag = document.createElement("script");
+        tag.src = "https://www.google.com/recaptcha/api.js?render=" + config.recaptchaSiteKey;
+        tag.onload = function () {
+          resolve();
+        };
+        tag.onerror = function () {
+          reject(new Error("Could not load reCAPTCHA. Check the site key and the network."));
+        };
+        document.head.appendChild(tag);
+      });
+    }
+    // Mint the token on submit, not on page load: a reCAPTCHA v3 token is only valid for
+    // ~2 minutes, so minting it earlier means it can already be expired by the time the
+    // visitor actually submits the form.
+    function mintToken() {
+      return loadRecaptcha().then(function () {
+        return new Promise(function (resolve, reject) {
+          window.grecaptcha.ready(function () {
+            window.grecaptcha
+              .execute(config.recaptchaSiteKey, { action: config.recaptchaAction })
+              .then(resolve, reject);
+          });
+        });
+      });
+    }
+    // Allowlist, not a denylist: only utm_* params and the names you seeded in
+    // trackedParams are collected. The rest of the query string can carry ad-network
+    // click ids or session tokens that were never meant to be stored -- over-collection
+    // here is irreversible, so when in doubt leave a param out.
+    function readCampaignParams() {
+      var params = new URLSearchParams(window.location.search);
+      var collected = {};
+      params.forEach(function (value, key) {
+        if (key.indexOf("utm_") === 0 || config.trackedParams.indexOf(key) !== -1) {
+          collected[key] = value;
+        }
+      });
+      return collected;
+    }
+    function buildPayload(token) {
+      return {
+        workspaceId: config.workspaceId,
+        captureKey: config.captureKey,
+        cellphone: document.getElementById("lead-phone").value.trim(),
+        name: document.getElementById("lead-name").value.trim() || null,
+        brandId: config.brandId,
+        // origin + pathname only, never the full URL: the query string can carry
+        // click ids or session tokens, and UTMs already travel separately in "utm" above.
+        landingUri: window.location.origin + window.location.pathname,
+        utm: readCampaignParams(),
+        consent: { status: "GRANTED", capturedAt: new Date().toISOString() },
+        recaptchaToken: token,
+      };
+    }
+    form.addEventListener("submit", function (event) {
+      event.preventDefault();
+      if (!document.getElementById("lead-consent").checked) {
+        return;
+      }
+      // A token verifies once; a retry that reuses the same token is indistinguishable
+      // from a replay attack and comes back as the same CAPTCHA_REJECTED error as a low
+      // score, so mint a fresh token on every submit attempt, including retries.
+      mintToken()
+        .then(function (token) {
+          var payload = buildPayload(token);
+          // workspaceId must be on the POST URL itself, not only in the body: a CORS
+          // preflight carries no body, so the endpoint cannot resolve the tenant --
+          // and therefore cannot echo Access-Control-Allow-Origin -- without it.
+          var url = config.endpoint + "?workspaceId=" + encodeURIComponent(config.workspaceId);
+          return fetch(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+          });
+        })
+        .then(function (response) {
+          if (response.status === 202) {
+            // Accepted and queued, not sent -- a separate service transmits the first
+            // WhatsApp message later. Tell the visitor "we'll message you shortly", not
+            // "message sent".
+            return;
+          }
+          return response.json().then(function (body) {
+            // RFC 9457 problem details: { type, title, status }, sometimes "detail".
+            // Error responses carry no request id, so if you need support, report the page
+            // URL and the approximate time. A 422 is a transient failure on our side and
+            // retrying it is safe; a 403 CAPTCHA_REJECTED usually means the token expired
+            // or was reused, so mint a fresh one before retrying.
+            throw new Error(body.type + ": " + (body.detail || body.title));
+          });
+        })
+        .catch(function (error) {
+          // eslint-disable-next-line no-console
+          console.error("Campaign lead submission failed", error);
+        });
+    });
+  })(window.__CAMPAIGN_LEADS__);
+</script>
+```
+
+## Your capture key is not an API key
+
+<Note>
+  If you have read the [Authentication](/credentials) page, it tells you never to put a key
+  in frontend code. That rule is about the Integrations API key, and it still holds. Your
+  `captureKey` is a different kind of value.
+</Note>
+
+Unlike the `x-api-key` used by the Integrations API, your `captureKey` is designed to live
+in your page's HTML where anyone can read it. It grants no read access to anything: it only
+identifies which workspace a submission belongs to. Abuse is bounded by two other checks —
+the reCAPTCHA token, and the fact that submissions are only accepted from the domains
+registered for your workspace.
+
+Never use your Integrations API key here, and never put one in a page.
+
+## Put the workspace id on the URL
+
+The workspace id goes in the request body **and** on the URL as `?workspaceId=...`. It has
+to be in both places: a browser sends a CORS preflight before the real request, and that
+preflight carries no body — so without the id on the URL we cannot tell which workspace you
+are, cannot return the header that authorises your domain, and the browser blocks the
+request before it is ever sent.
+
+The failure this causes is confusing, which is why it is worth getting right the first
+time: you will see a CORS error in the browser console and no request in our logs at all,
+because the real request never left the page.
+
+## Mint the captcha token when the form is submitted
+
+A reCAPTCHA v3 token is valid for about two minutes. Minting it when the page loads means
+it is often already expired by the time somebody finishes typing, and it comes back
+rejected — as a `403`, which looks like a permissions problem rather than a timing one.
+
+## Mint a new token for every attempt
+
+A token verifies exactly once. If a submission fails and you retry with the same token, the
+replay is indistinguishable from an attack and returns the same error a bot would get.
+Always call `grecaptcha.execute` again before retrying.
+
+## What to send
+
+The [endpoint reference](/api-reference/campaign-leads/register-a-campaign-lead) carries the full contract.
+These are the fields whose meaning is not obvious from the schema alone:
+
+<ResponseField name="brandId" type="string">
+  The brand your landing page sells — not a line, channel or phone number id. Required only
+  if your workspace has brands enabled. **A line id is never required.**
+</ResponseField>
+
+<ResponseField name="landingUri" type="string">
+  The page's origin and path, without the query string. Your UTMs travel separately in
+  `utm`, and a raw query string often carries click ids or session tokens that should not be
+  stored. Send `https://example.com/offer`, not `https://example.com/offer?gclid=...`.
+</ResponseField>
+
+<ResponseField name="consent" type="object">
+  Your attestation that the visitor opted in, and when. See
+  [Consent requirements](/lead-capture/consent) — the wording on your form is not optional.
+</ResponseField>
+
+<ResponseField name="utm" type="object">
+  Collected from the query string against an allowlist: `utm_*` parameters plus any extra
+  names you configure in the console. This is an allowlist rather than a denylist on
+  purpose — over-collecting here is not reversible.
+</ResponseField>
+
+## After you submit
+
+A `202` means the lead was accepted and queued. It does **not** mean a message was sent —
+that happens later, in a separate service. Tell the visitor you will message them shortly.
+
+Anything else is an error. See the [error reference](/lead-capture/errors) for what each one
+means and whether it is yours to fix.

--- a/lead-capture/templates.mdx
+++ b/lead-capture/templates.mdx
@@ -1,0 +1,54 @@
+---
+title: "Template requirements"
+sidebarTitle: "Templates"
+description: "Why the message that opens the conversation must stay strictly transactional."
+keywords: ["template", "utility", "marketing", "131049", "WhatsApp"]
+---
+
+## The rule
+
+The template that opens the conversation must be a **utility** template: strictly
+transactional, echoing what the visitor just submitted. No offers, no discounts, no
+promotional language, and no purchase call to action.
+
+You configure and submit this template yourself, and getting it approved is a prerequisite
+for going live.
+
+## Why, and why it is not a style preference
+
+<Warning>
+  Meta classifies templates by their content, not by the category you select. A template it
+  reclassifies as MARKETING stops being deliverable under the same conditions — it begins
+  failing with error `131049`, which does not announce itself. Your sends simply stop
+  arriving.
+</Warning>
+
+That silence is the whole problem. A rejected template is obvious; a reclassified one is
+not. Keeping the first message strictly transactional is what keeps it working, which is
+why this reads as protection rather than paperwork.
+
+## The line, shown rather than described
+
+**Compliant** — it acknowledges an action the person just took and offers nothing:
+
+```text
+Hi {{1}}, thanks for your enquiry about the {{2}}. A member of our team will follow up here shortly.
+```
+
+**Not compliant** — same opening, but the second sentence turns it into an advertisement:
+
+```text
+Hi {{1}}, thanks for your enquiry about the {{2}}. Book this week and get 15% off — reply YES to claim.
+```
+
+The difference is not tone or length. It is whether the message exists to confirm something
+the person did, or to sell them something they did not ask for.
+
+## Practical guidance
+
+- Echo the specifics the visitor gave you. A message that repeats their enquiry reads as
+  transactional because it is.
+- Do not include prices, promotions, urgency, or a call to action to buy.
+- Do not use the first message to introduce products they did not ask about.
+- Once the person replies, you are in a normal conversation and these constraints no longer
+  apply. The restriction is on the message that opens it.


### PR DESCRIPTION
Publishes tenant-facing documentation for the public campaign-leads endpoint as a new **Lead Capture** tab.

Implements Goal 5 (epic #1642), deliverables 1–3. The measured pilot, the COP rate card and the tenant test path are field work or blocked on the staging rollout, and are not in scope here.

## The endpoint reference is generated, never hand-written

`api-reference/campaign-leads.openapi.yaml` is produced from the Lambda's own route definitions with AWS Lambda Powertools. **Do not edit it by hand.** To publish a contract change, regenerate it:

```bash
RECAPTCHA_SECRET=x DISPATCH_QUEUE_URL=x UNEVALUATED_LEADS_QUEUE_URL=x \
  .venv/bin/python apps/bridge-ai-campaign-capture-api/scripts/generate_openapi.py
```

(from the root of `bridge-ai-processors-monorepo`), then paste the output over the file and open a PR here. This file is the only committed copy of the contract, so the diff in that PR *is* the contract change.

## Depends on an unmerged PR

The spec in this PR was generated from `Sainapsis/bridge-ai-processors-monorepo#59`, which is **still open**. That PR adds the route metadata that makes the generated document correct — before it, generation emitted a dangling `$ref` and the endpoint documented with no request body at all. **This PR should not merge before that one.** If review changes the contract there, the file here must be regenerated.

## What is in the tab

Two audiences, split into two groups.

**Integration** — for the tenant's web developer: an overview that leads with the `202`-means-accepted rule, the integration guide with the pasteable example, the error reference, and the generated endpoint reference.

**Before you launch** — for the tenant's marketing and compliance side: consent wording requirements and utility-template requirements.

## Notable content decisions

- **The example is extracted from the console, not retyped.** It comes from `buildIntegrationExample` in `consoles-ui-monorepo`, so the console and the docs stay one source with a copy step rather than two hand-maintained copies.
- **One correction was applied during extraction.** The console's copy comments the `422` as `TENANT_MISCONFIGURED`. That code is defined in the API but never raised — the only `422` the endpoint returns is `CAPTCHA_PROVIDER_UNAVAILABLE`, which is transient and safe to retry. The published version says that instead. The console source still needs the same fix; it is deferred because that repo has a PR in review.
- **`captureKey` is explained as not being an API key.** The existing Authentication page states in bold that keys must never appear in frontend code. A reader who has seen it will think this page contradicts it, so the integration guide addresses that head-on rather than leaving the reader to reconcile the two.
- **No request id on errors.** Verified: only the `202` carries one. The error page tells readers to report the page URL and approximate time, rather than promising a request id that does not exist.
- **The reCAPTCHA score threshold is not published anywhere**, deliberately.
- **Production server only.** Staging and dev hosts are internal; staging gets added when tenants get a pre-launch validation path.

## `docs.json` instructions were rewritten, and this is not cosmetic

The `markdown.instructions` block steers the documentation assistant across the whole site. It asserted as global truths that there is one host, that every request carries `x-api-key`, and that error codes are shaped `BRIDGE_<DOMAIN>_<NNNN>`. All three are false for this endpoint, so leaving them would have the assistant contradict the pages this PR adds. Each claim is now scoped to the Integrations API, with an explicit carve-out for the public surface.

## Validation

- `npx mint openapi-check api-reference/campaign-leads.openapi.yaml` — valid
- `npx mint broken-links` — no broken links
- `docs.json` parses
- Verified in the generated document: no dangling `$ref`, `CampaignLeadRequestDto` and `ConsentDto` fully present, `capturedAt` typed as an ISO 8601 string, only the `post` method (the CORS preflight is excluded), and all five statuses declared.

The pages were rendered locally with `mint dev`; the endpoint page resolves at `/api-reference/campaign-leads/register-a-campaign-lead`. Note that this slug derives from the operation's `summary`, so changing that text in the route decorator changes this URL.